### PR TITLE
F dev 0005 login register fix

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -27,6 +27,7 @@ module.exports = {
         allow: ['error'],
       },
     ],
+    'react/prop-types': 'off',
     // Disable the rule that requires React to be in scope when using JSX
     'react/react-in-jsx-scope': 'off',
     // Disable the warning about missing displayName in React components

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-hot-toast": "^2.4.1",
     "react-icons": "^5.3.0",
     "react-loader-spinner": "^6.1.6",
     "react-redux": "^9.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,6 @@
     "clsx": "^2.1.1",
     "formik": "^2.4.6",
     "modern-normalize": "^3.0.1",
-    "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hot-toast": "^2.4.1",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,5 @@
 import { Routes, Route } from 'react-router-dom';
+import { Toaster } from 'react-hot-toast';
 import HomePage from '../src/pages/HomePage/HomePage';
 import CartPage from '../src/pages/CartPage/CartPage';
 import SharedLayout from './components/SharedLayout/SharedLayout';
@@ -7,7 +8,7 @@ import NotFoundPage from './pages/NotFoundPage/NotFoundPage';
 import SupportPage from './pages/SupportPage/SupportPage';
 
 export default function App() {
-	return (
+  return (
     <>
       <ModalParentComponent />
       <Routes>
@@ -18,7 +19,7 @@ export default function App() {
           <Route path="*" element={<NotFoundPage />} />
         </Route>
       </Routes>
+      <Toaster />
     </>
   );
 }
-

--- a/frontend/src/components/ChangePwdModal/ChangePwdModal.jsx
+++ b/frontend/src/components/ChangePwdModal/ChangePwdModal.jsx
@@ -35,7 +35,8 @@ export default function ChangePwdModal() {
   };
 
   const handleSubmit = async (values, actions) => {
-    const newPwd = values.password;
+		const newPwd = values.password;
+		localStorage.setItem('newPwd', newPwd);
 
     function resetFormData() {
       setShowInfo(false);

--- a/frontend/src/components/ChangePwdModal/ChangePwdModal.jsx
+++ b/frontend/src/components/ChangePwdModal/ChangePwdModal.jsx
@@ -54,7 +54,7 @@ export default function ChangePwdModal() {
       })
       .catch((e) => {
 				resetFormData();
-				return thunkAPI.rejectWithValue(e.message);
+				console.error('Change password failed:', e.message); 
       });
   };
 

--- a/frontend/src/components/CodeVerificationModal/CodeVerificationModal.jsx
+++ b/frontend/src/components/CodeVerificationModal/CodeVerificationModal.jsx
@@ -111,16 +111,10 @@ const CodeVerificationModal = ({ type }) => {
 
         if (type === 'verification-register') {
           openModal('confirmation-modal', { type });
-          const keysToRemove = [
-            'emailForResendRegisterCode',
-            'verifyResetCode',
-            'passwordForResendRegisterCode',
-          ];
 
-          keysToRemove.forEach((key) => localStorage.removeItem(key));
+          localStorage.removeItem('verifyResetCode');
         } else if (type === 'verification-reset') {
           openModal('change-pwd');
-          localStorage.removeItem('emailForReset');
         }
       })
       .catch((e) => {

--- a/frontend/src/components/CodeVerificationModal/CodeVerificationModal.jsx
+++ b/frontend/src/components/CodeVerificationModal/CodeVerificationModal.jsx
@@ -3,7 +3,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useId, useState } from 'react';
 import { Formik, Field, Form } from 'formik';
 import clsx from 'clsx';
-import PropTypes from 'prop-types';
 import { useModal } from '../../hooks/useModal';
 import { selectLoading, selectUser } from '../../redux/auth/selectors';
 import { registerComplete, verifyCode } from '../../redux/auth/operations';
@@ -99,8 +98,10 @@ const CodeVerificationModal = ({ type }) => {
         }
       })
       .catch((e) => {
-				setAuthError(true);
-				return thunkAPI.rejectWithValue(e.message);
+        setAuthError(true);
+        console.error('Code verification:', e.message);
+        actions.resetForm();
+        setOtp(Array(6).fill(''));
       });
   };
 
@@ -180,8 +181,3 @@ const CodeVerificationModal = ({ type }) => {
 };
 
 export default CodeVerificationModal;
-
-CodeVerificationModal.propTypes = {
-  type: PropTypes.oneOf(['verification-register', 'verification-reset'])
-    .isRequired,
-};

--- a/frontend/src/components/CodeVerificationModal/CodeVerificationModal.jsx
+++ b/frontend/src/components/CodeVerificationModal/CodeVerificationModal.jsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
-import { useId, useState } from 'react';
+import { useId, useState, useEffect } from 'react';
 import { Formik, Field, Form } from 'formik';
 import clsx from 'clsx';
 import { useModal } from '../../hooks/useModal';
@@ -29,11 +29,12 @@ const CodeVerificationModal = ({ type }) => {
       : 'Введіть унікальний 6-значний код, який був висланий на ваш e-mail';
   };
 
-  const handleKeyDown = (e, index) => {
-    if (e.key === 'Backspace' && !otp[index] && index > 0) {
-      document.getElementById(`${id}-code-${index - 1}`).focus();
+  useEffect(() => {
+    const firstInput = document.getElementById(`${id}-code-0`);
+    if (firstInput) {
+      firstInput.focus();
     }
-  };
+  }, [id]);
 
   const handleChange = (e, index, setFieldValue) => {
     const value = e.target.value;
@@ -43,12 +44,26 @@ const CodeVerificationModal = ({ type }) => {
       setOtp(newOtp);
       setFieldValue('code', newOtp);
 
+      if (value && index < otp.length - 1) {
+        document
+          .getElementById(`${id}-code-${index + 1}`)
+          .removeAttribute('disabled');
+        document.getElementById(`${id}-code-${index + 1}`).focus();
+      }
+
       if (newOtp.every((digit) => digit !== '')) {
         handleSubmit({ code: newOtp }, { resetForm: () => {} });
       }
+    }
+  };
 
-      if (value && index < otp.length - 1) {
-        document.getElementById(`${id}-code-${index + 1}`).focus();
+  const handleKeyDown = (e, index) => {
+    if (e.key === 'Backspace') {
+      if (!otp[index] && index > 0) {
+        document.getElementById(`${id}-code-${index - 1}`).focus();
+        const newOtp = [...otp];
+        newOtp[index - 1] = '';
+        setOtp(newOtp);
       }
     }
   };
@@ -60,6 +75,11 @@ const CodeVerificationModal = ({ type }) => {
       setOtp(newOtp);
       newOtp.forEach((value, index) => {
         document.getElementById(`${id}-code-${index}`).value = value;
+        if (index < otp.length - 1) {
+          document
+            .getElementById(`${id}-code-${index + 1}`)
+            .removeAttribute('disabled');
+        }
       });
       setFieldValue('code', newOtp);
 
@@ -162,6 +182,7 @@ const CodeVerificationModal = ({ type }) => {
                             authError && css.inputError
                           )}
                           autoComplete="off"
+                          disabled={index > 0 && !otp[index - 1]}
                         />
                       </label>
                     ))}

--- a/frontend/src/components/CodeVerificationModal/CodeVerificationModal.jsx
+++ b/frontend/src/components/CodeVerificationModal/CodeVerificationModal.jsx
@@ -38,6 +38,7 @@ const CodeVerificationModal = ({ type }) => {
 
   const handleChange = (e, index, setFieldValue) => {
     const value = e.target.value;
+
     if (/^\d$/.test(value) || value === '') {
       const newOtp = [...otp];
       newOtp[index] = value;
@@ -59,11 +60,33 @@ const CodeVerificationModal = ({ type }) => {
 
   const handleKeyDown = (e, index) => {
     if (e.key === 'Backspace') {
-      if (!otp[index] && index > 0) {
-        document.getElementById(`${id}-code-${index - 1}`).focus();
+      if (index === otp.length - 1 || otp[index] === '') {
         const newOtp = [...otp];
-        newOtp[index - 1] = '';
+
+        if (otp[index] !== '') {
+          newOtp[index] = '';
+        } else if (index > 0) {
+          newOtp[index - 1] = '';
+          document.getElementById(`${id}-code-${index - 1}`).focus();
+        }
+
         setOtp(newOtp);
+
+        setTimeout(() => {
+          otp.forEach((_, i) => {
+            if (i > index) {
+              document
+                .getElementById(`${id}-code-${i}`)
+                .setAttribute('disabled', true);
+            } else {
+              document
+                .getElementById(`${id}-code-${i}`)
+                .removeAttribute('disabled');
+            }
+          });
+        }, 0);
+      } else {
+        e.preventDefault();
       }
     }
   };

--- a/frontend/src/components/CodeVerificationModal/CodeVerificationModal.jsx
+++ b/frontend/src/components/CodeVerificationModal/CodeVerificationModal.jsx
@@ -91,10 +91,16 @@ const CodeVerificationModal = ({ type }) => {
 
         if (type === 'verification-register') {
           openModal('confirmation-modal', { type });
-          localStorage.removeItem('ResendRegisterCode');
-          localStorage.removeItem('verifyResetCode');
+          const keysToRemove = [
+            'emailForResendRegisterCode',
+            'verifyResetCode',
+            'passwordForResendRegisterCode',
+          ];
+
+          keysToRemove.forEach((key) => localStorage.removeItem(key));
         } else if (type === 'verification-reset') {
           openModal('change-pwd');
+          localStorage.removeItem('emailForReset');
         }
       })
       .catch((e) => {

--- a/frontend/src/components/CodeVerificationModal/CodeVerificationModal.module.css
+++ b/frontend/src/components/CodeVerificationModal/CodeVerificationModal.module.css
@@ -80,6 +80,10 @@
   border-color: var(--default-black);
 }
 
+.input.filled:focus {
+  border-color: var(--default-black);
+}
+
 .input:hover {
   border-color: var(--primary-yellow);
 }

--- a/frontend/src/components/CodeVerificationModal/CodeVerificationModal.module.css
+++ b/frontend/src/components/CodeVerificationModal/CodeVerificationModal.module.css
@@ -1,5 +1,5 @@
 .container {
-	position: relative;
+  position: relative;
   display: flex;
 }
 

--- a/frontend/src/components/ConfirmationModal/ConfirmationModal.jsx
+++ b/frontend/src/components/ConfirmationModal/ConfirmationModal.jsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import { useModal } from '../../hooks/useModal';
 import FormImgComponent from '../../components/FormImgComponent/FormImgComponent';
 import css from './ConfirmationModal.module.css';
@@ -36,7 +35,4 @@ export default function ConfirmationModal({ type }) {
   );
 }
 
-ConfirmationModal.propTypes = {
-  type: PropTypes.oneOf(['verification-register', 'verification-reset'])
-    .isRequired,
-};
+

--- a/frontend/src/components/ConfirmationModal/ConfirmationModal.jsx
+++ b/frontend/src/components/ConfirmationModal/ConfirmationModal.jsx
@@ -1,9 +1,18 @@
+import { useDispatch, useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+import { logIn } from '../../redux/auth/operations';
 import { useModal } from '../../hooks/useModal';
+import { selectLoading } from '../../redux/auth/selectors';
+import Loader from '../Loader/Loader';
 import FormImgComponent from '../../components/FormImgComponent/FormImgComponent';
 import css from './ConfirmationModal.module.css';
 
 export default function ConfirmationModal({ type }) {
-  const { openModal } = useModal();
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const { closeModal } = useModal();
+
+  const isLoading = useSelector(selectLoading);
 
   const getTitle = () => {
     return type === 'verification-register'
@@ -17,22 +26,58 @@ export default function ConfirmationModal({ type }) {
       : 'Тепер ви можете зайти на cвій акаунт використовуючи новий пароль';
   };
 
+  const handleSubmit = async () => {
+    const email = localStorage.getItem('emailForResendRegisterCode');
+    const password = localStorage.getItem('passwordForResendRegisterCode');
+    const emailForReset = localStorage.getItem('emailForReset');
+    const newPwd = localStorage.getItem('newPwd');
+
+    let dispatchAction;
+
+    if (type === 'verification-register') {
+      dispatchAction = logIn({ email, password });
+    } else {
+      dispatchAction = logIn({ email: emailForReset, password: newPwd });
+    }
+
+    try {
+      await dispatch(dispatchAction).unwrap();
+
+      // Clean up local storage
+      const keysToRemove =
+        type === 'verification-register'
+          ? ['emailForResendRegisterCode', 'passwordForResendRegisterCode']
+          : ['emailForReset', 'newPwd'];
+
+      keysToRemove.forEach((key) => localStorage.removeItem(key));
+
+      closeModal();
+      navigate('/private');
+    } catch (e) {
+      console.error('Error during the dispatch:', e.message);
+      // Optionally, you can show a user-friendly error message here
+    }
+  };
+
   return (
     <div className={css.container}>
       <FormImgComponent />
-      <div className={css.pageContent}>
-        <h2 className={css.title}>{getTitle()}</h2>
-        <p className={css.additionalInfo}>{getDescription()}</p>
-        <button
-          type="button"
-          onClick={() => openModal('login')}
-          className={css.loginLink}
-        >
-          Увійти
-        </button>
-      </div>
+
+      {isLoading ? (
+        <Loader />
+      ) : (
+        <div className={css.pageContent}>
+          <h2 className={css.title}>{getTitle()}</h2>
+          <p className={css.additionalInfo}>{getDescription()}</p>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            className={css.loginLink}
+          >
+            Увійти
+          </button>
+        </div>
+      )}
     </div>
   );
 }
-
-

--- a/frontend/src/components/ForgotPassword/ForgotPassword.jsx
+++ b/frontend/src/components/ForgotPassword/ForgotPassword.jsx
@@ -26,7 +26,7 @@ export default function ForgotPassword() {
         openModal('verification-reset');
       })
 			.catch((e) => {
-				return thunkAPI.rejectWithValue(e.message);
+				console.error('Reset password failed:', e.message); 
       });
   };
 

--- a/frontend/src/components/ForgotPassword/ForgotPassword.jsx
+++ b/frontend/src/components/ForgotPassword/ForgotPassword.jsx
@@ -59,7 +59,7 @@ export default function ForgotPassword() {
             onSubmit={handleSubmit}
             validationSchema={forgotPasswordSchema}
           >
-            {({ isValid, dirty, values, errors }) => (
+            {({ values, errors }) => (
               <Form>
                 <div className={css.inputWrapEmail}>
                   <label htmlFor={`${id}-email`}>

--- a/frontend/src/components/LoginForm/LoginForm.jsx
+++ b/frontend/src/components/LoginForm/LoginForm.jsx
@@ -49,8 +49,6 @@ export default function LoginForm() {
       userRemember: values.userRemember,
     };
 
-    console.log(user);
-
     dispatch(logIn(user))
       .unwrap()
       .then(() => {

--- a/frontend/src/components/LoginForm/LoginForm.jsx
+++ b/frontend/src/components/LoginForm/LoginForm.jsx
@@ -18,7 +18,6 @@ export default function LoginForm() {
   const [showPassword, setShowPassword] = useState(false);
   const [type, setType] = useState('password');
   const [authError, setAuthError] = useState(false);
-  const [isButtonEnabled, setIsButtonEnabled] = useState(false);
   const [inputError, setInputError] = useState({
     email: false,
     password: false,
@@ -107,7 +106,7 @@ export default function LoginForm() {
             validationSchema={schema}
             onSubmit={handleSubmit}
           >
-            {({ errors, touched, values, isValid, dirty }) => (
+            {({ errors, touched, values }) => (
               <Form>
                 <div className={css.inputWrapEmail}>
                   <label className={css.inputLabel} htmlFor={`${id}-email`}>

--- a/frontend/src/components/LoginForm/LoginForm.jsx
+++ b/frontend/src/components/LoginForm/LoginForm.jsx
@@ -18,6 +18,7 @@ export default function LoginForm() {
   const [showPassword, setShowPassword] = useState(false);
   const [type, setType] = useState('password');
   const [authError, setAuthError] = useState(false);
+  const [isButtonEnabled, setIsButtonEnabled] = useState(false);
   const [inputError, setInputError] = useState({
     email: false,
     password: false,
@@ -43,12 +44,15 @@ export default function LoginForm() {
   const handleSubmit = async (values, actions) => {
     setInputError({ email: false, password: false });
 
-    dispatch(
-      logIn({
-        user: { email: values.email, password: values.password },
-        userRemember: values.userRemember,
-      })
-    )
+    const user = {
+      email: values.email,
+      password: values.password,
+      userRemember: values.userRemember,
+    };
+
+    console.log(user);
+
+    dispatch(logIn(user))
       .unwrap()
       .then(() => {
         setAuthError(false);
@@ -59,7 +63,7 @@ export default function LoginForm() {
       .catch((e) => {
         setAuthError(true);
         setInputError({ email: true, password: true });
-        return thunkAPI.rejectWithValue(e.message);
+        console.error('Login failed:', e.message);
       });
   };
 
@@ -215,7 +219,12 @@ export default function LoginForm() {
                 <button
                   className={css.styledButton}
                   type="submit"
-                  disabled={!(isValid && dirty)}
+                  disabled={
+                    !values.email ||
+                    !values.password ||
+                    !!errors.email ||
+                    !!errors.password
+                  }
                 >
                   Увійти
                 </button>

--- a/frontend/src/components/LoginForm/LoginForm.jsx
+++ b/frontend/src/components/LoginForm/LoginForm.jsx
@@ -1,6 +1,6 @@
 import { useState, useId } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-//import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { logIn } from '../../redux/auth/operations';
 import { Formik, Form, Field } from 'formik';
 import clsx from 'clsx';
@@ -27,7 +27,7 @@ export default function LoginForm() {
   const { openModal } = useModal();
   const id = useId();
   const dispatch = useDispatch();
-  //const navigate = useNavigate();
+  const navigate = useNavigate();
   const { closeModal } = useModal();
 
   const togglePassInput = () => {
@@ -57,7 +57,7 @@ export default function LoginForm() {
         setAuthError(false);
         actions.resetForm();
         closeModal();
-        //navigate('/private');
+        navigate('/private');
       })
       .catch((e) => {
         setAuthError(true);

--- a/frontend/src/components/ModalWrapper/ModalWrapper.jsx
+++ b/frontend/src/components/ModalWrapper/ModalWrapper.jsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import { useModal } from '../../hooks/useModal';
 import { useClickOutsideAndEsc } from '../../hooks/useClickOutsideAndEsc';
 import { RxCross2 } from 'react-icons/rx';
@@ -30,6 +29,4 @@ const ModalWrapper = ({ children }) => {
 
 export default ModalWrapper;
 
-ModalWrapper.propTypes = {
-  children: PropTypes.node, 
-};
+

--- a/frontend/src/components/RegisterForm/RegisterForm.jsx
+++ b/frontend/src/components/RegisterForm/RegisterForm.jsx
@@ -5,7 +5,7 @@ import { Formik, Form, Field } from 'formik';
 import clsx from 'clsx';
 import toast from 'react-hot-toast';
 import { useModal } from '../../hooks/useModal';
-import { selectLoading } from '../../redux/auth/selectors';
+import { selectLoading, selectUser } from '../../redux/auth/selectors';
 import Loader from '../Loader/Loader';
 import FormImgComponent from '../../components/FormImgComponent/FormImgComponent';
 import { FiEye, FiEyeOff } from 'react-icons/fi';
@@ -45,18 +45,21 @@ export default function RegisterForm() {
       localStorage.setItem('passwordForResendRegisterCode', password);
     };
 
+    const confirmRegister = () => {
+      resetFormData();
+      openModal('verification-register');
+    };
+
     dispatch(register(newUser))
       .unwrap()
       .then(() => {
         saveToLocalStorage(newUser.email, newUser.password);
-        resetFormData();
-        openModal('verification-register');
+        confirmRegister();
       })
       .catch((e) => {
         if (e === 'Request failed with status code 307') {
           saveToLocalStorage(newUser.email, newUser.password);
-          resetFormData();
-          openModal('verification-register');
+          confirmRegister();
         } else {
           resetFormData();
           toast('Користувач з такою поштою вже зареєстрований');

--- a/frontend/src/components/RegisterForm/RegisterForm.jsx
+++ b/frontend/src/components/RegisterForm/RegisterForm.jsx
@@ -52,7 +52,7 @@ export default function RegisterForm() {
           openModal('verification-register');
         } else {
 					resetFormData();
-					return thunkAPI.rejectWithValue(e.message);
+					console.error('Register failed:', e.message); 
         }
       });
   };

--- a/frontend/src/components/ResendCodeBtn/ResendCodeBtn.jsx
+++ b/frontend/src/components/ResendCodeBtn/ResendCodeBtn.jsx
@@ -1,5 +1,5 @@
 import { useDispatch, useSelector } from 'react-redux';
-import { selectLoading, selectUser } from '../../redux/auth/selectors';
+import { selectUser } from '../../redux/auth/selectors';
 import {
   resendRegisterCode,
   forgotPassword,
@@ -7,7 +7,6 @@ import {
 import css from './ResendCodeBtn.module.css';
 
 const ResendCodeBtn = ({ type }) => {
-  const isLoading = useSelector(selectLoading);
   const email = useSelector(selectUser);
   const dispatch = useDispatch();
 
@@ -18,32 +17,23 @@ const ResendCodeBtn = ({ type }) => {
 
     if (type === 'verification-register') {
       action = resendRegisterCode({ email: newUserEmail });
-    } else if (type === 'verification-reset') {
-      action = forgotPassword({ email: email });
     } else {
-      console.error('Invalid operation type');
-      return;
+      action = forgotPassword({ email: email });
     }
 
     dispatch(action)
       .unwrap()
       .then(() => {})
       .catch((e) => {
-        console.error('Resend code verification failed:', e.message); 
+        console.error('Resend code verification failed:', e.message);
       });
   };
 
   return (
-    <button
-      type="button"
-      onClick={handleSubmit}
-      className={css.submitButton}
-    >
+    <button type="button" onClick={handleSubmit} className={css.submitButton}>
       Надіслати код
     </button>
   );
 };
 
 export default ResendCodeBtn;
-
-

--- a/frontend/src/components/ResendCodeBtn/ResendCodeBtn.jsx
+++ b/frontend/src/components/ResendCodeBtn/ResendCodeBtn.jsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { selectLoading, selectUser } from '../../redux/auth/selectors';
 import {
@@ -30,7 +29,7 @@ const ResendCodeBtn = ({ type }) => {
       .unwrap()
       .then(() => {})
       .catch((e) => {
-        return thunkAPI.rejectWithValue(e.message);
+        console.error('Resend code verification failed:', e.message); 
       });
   };
 
@@ -40,14 +39,11 @@ const ResendCodeBtn = ({ type }) => {
       onClick={handleSubmit}
       className={css.submitButton}
     >
-      Повторно надіслати код
+      Надіслати код
     </button>
   );
 };
 
 export default ResendCodeBtn;
 
-ResendCodeBtn.propTypes = {
-  type: PropTypes.oneOf(['verification-register', 'verification-reset'])
-    .isRequired,
-};
+

--- a/frontend/src/redux/auth/operations.js
+++ b/frontend/src/redux/auth/operations.js
@@ -38,27 +38,33 @@ export const registerComplete = createAsyncThunk(
   }
 );
 
-export const logIn = createAsyncThunk('auth/login', async (user, thunkAPI) => {
-  try {
-    const res = await axios.post('/api/auth/login/', user);
-    const accessToken = res.data.access;
-    const refreshToken = res.data.refresh;
-    setAuthHeader(accessToken);
-    localStorage.setItem('accessToken', accessToken);
-    localStorage.setItem('refreshToken', refreshToken);
+export const logIn = createAsyncThunk(
+  'auth/login',
+  async ({ email, password, userRemember }, thunkAPI) => {
+    try {
+      const res = await axios.post('/api/auth/login/', {
+        email,
+        password,
+      });
+      const accessToken = res.data.access;
+      const refreshToken = res.data.refresh;
+      setAuthHeader(accessToken);
+      localStorage.setItem('accessToken', accessToken);
+      localStorage.setItem('refreshToken', refreshToken);
 
-    if (user) {
-      localStorage.setItem('email', user.email);
-      localStorage.setItem('password', user.password);
-    } else {
-      localStorage.removeItem('email');
-      localStorage.removeItem('password');
+      if (userRemember) {
+        localStorage.setItem('email', email);
+        localStorage.setItem('password', password);
+      } else {
+        localStorage.removeItem('email');
+        localStorage.removeItem('password');
+      }
+      return res.data;
+    } catch (e) {
+      return thunkAPI.rejectWithValue(e.message);
     }
-    return res.data;
-  } catch (e) {
-    return thunkAPI.rejectWithValue(e.message);
   }
-});
+);
 
 export const logOut = createAsyncThunk('auth/logout', async (_, thunkAPI) => {
   try {
@@ -124,8 +130,6 @@ export const resetPassword = createAsyncThunk(
         code,
         password,
       });
-      const accessToken = res.data.access;
-      setAuthHeader(accessToken);
       return res.data;
     } catch (e) {
       return thunkAPI.rejectWithValue(e);

--- a/frontend/src/redux/auth/operations.js
+++ b/frontend/src/redux/auth/operations.js
@@ -54,7 +54,6 @@ export const logIn = createAsyncThunk('auth/login', async (user, thunkAPI) => {
       localStorage.removeItem('email');
       localStorage.removeItem('password');
     }
-    console.log(res.data);
     return res.data;
   } catch (e) {
     return thunkAPI.rejectWithValue(e.message);

--- a/frontend/src/redux/auth/operations.js
+++ b/frontend/src/redux/auth/operations.js
@@ -38,29 +38,28 @@ export const registerComplete = createAsyncThunk(
   }
 );
 
-export const logIn = createAsyncThunk(
-  'auth/login',
-  async ({ user, userRemember }, thunkAPI) => {
-    try {
-      const res = await axios.post('/api/auth/login/', user);
-      const accessToken = res.data.access;
-      setAuthHeader(accessToken);
-      localStorage.setItem('accessToken', accessToken);
+export const logIn = createAsyncThunk('auth/login', async (user, thunkAPI) => {
+  try {
+    const res = await axios.post('/api/auth/login/', user);
+    const accessToken = res.data.access;
+    const refreshToken = res.data.refresh;
+    setAuthHeader(accessToken);
+    localStorage.setItem('accessToken', accessToken);
+    localStorage.setItem('refreshToken', refreshToken);
 
-      if (userRemember) {
-        localStorage.setItem('email', user.email);
-        localStorage.setItem('password', user.password);
-      } else {
-        localStorage.removeItem('email');
-        localStorage.removeItem('password');
-      }
-
-      return res.data;
-    } catch (e) {
-      return thunkAPI.rejectWithValue(e.message);
+    if (user) {
+      localStorage.setItem('email', user.email);
+      localStorage.setItem('password', user.password);
+    } else {
+      localStorage.removeItem('email');
+      localStorage.removeItem('password');
     }
+    console.log(res.data);
+    return res.data;
+  } catch (e) {
+    return thunkAPI.rejectWithValue(e.message);
   }
-);
+});
 
 export const logOut = createAsyncThunk('auth/logout', async (_, thunkAPI) => {
   try {


### PR DESCRIPTION
1. Save refresh and access tokens in localStorage.
2. Add that the checkbox parameter is sent to the backend.
3. After registration and password change, activate the client immediately.

4. Correct the cursor in the OTP code and implement sequential deletion of digits.
5. Auto-focus on the input field for the 6-digit code.
6. Cell highlighting: leave a red highlight for incorrect codes but clear the contents of the cells.

7. Save data when returning to "back to modal..."
8. Display an error for non-existent users or already registered users.
9. Change the description of the button for resending the code.