### PR TITLE
Fix error when save the translations

### DIFF
--- a/backend/apps/utils/translation/models.py
+++ b/backend/apps/utils/translation/models.py
@@ -52,8 +52,10 @@ class AutoTranslatableModel(TranslatableModel):
         languages = [code for (code, lang) in settings.LANGUAGES if code != self.language_code]
 
         for language in languages:
-            translated_value = self.translate(field_value, language)
-            self.create_translation(language, **{field_name: translated_value})
+            translated_value = self.translate(field_value, language).capitalize()
+
+            for translation in self._set_translated_fields(language, **{field_name: translated_value}):
+                self.save_translation(translation)
 
     def translate(self, value: str, target_language: str = "en") -> str:
         """Translate a value to a target language and return the translated value."""

--- a/backend/apps/utils/translation/tasks.py
+++ b/backend/apps/utils/translation/tasks.py
@@ -8,7 +8,7 @@ redis_client = caches["default"].client.get_client()
 @shared_task
 def translate_fields_task(app_label: str, instance_pk: int, language_code: str):
     """Create translations to each field in translatable_fields."""
-    lock_key = f"translate_task_lock_{instance_pk}"
+    lock_key = f"translate_task_lock_{app_label}:{instance_pk}"
 
     # Trying to capture the lock
     lock_acquired = redis_client.setnx(lock_key, "locked")

--- a/backend/apps/utils/translation/tests/test_model.py
+++ b/backend/apps/utils/translation/tests/test_model.py
@@ -2,6 +2,7 @@ import time
 
 import pytest
 from deep_translator import DeeplTranslator
+from django.conf import settings
 from django.db import transaction
 from django.utils.text import slugify
 from parler.models import TranslatableModelMixin
@@ -19,6 +20,11 @@ class TestAutoTranslatableModel:
 
         self.translated_name = f"Translated {self.instance_name}"
         self.mock_translate = mocker.patch.object(DeeplTranslator, "translate", return_value=self.translated_name)
+
+        self.mock_set_translated_fields = mocker.patch.object(
+            self.instance, "_set_translated_fields", side_effect=self.instance._set_translated_fields
+        )
+        self.mock_save_translation = mocker.patch.object(TranslatableModelMixin, "save_translation")
 
     def test_str_method(self):
         assert str(self.instance) == self.instance_name
@@ -78,14 +84,24 @@ class TestAutoTranslatableModel:
         assert translated_fields == ["name"]
 
     def test_translate_field(self, mocker):
-        # Mock `create_translation` method
-        mocker.patch.object(TranslatableModelMixin, "create_translation")
-
         # Translating a specific field
-        self.instance.translate_field("name", "Test Name")
+        self.instance.translate_field("name", self.instance_name)
 
-        # Check that the `translate` method has been called
-        self.mock_translate.assert_called()
+        # Get a language list
+        languages = [code for (code, lang) in settings.LANGUAGES if code != self.instance.language_code]
+
+        # Check that the `translate` method has been called with instance name
+        expected_calls = [mocker.call(self.instance_name) for _ in range(len(languages))]
+        self.mock_translate.assert_has_calls(expected_calls, any_order=False)
+        assert self.mock_translate.call_count == len(expected_calls)
+
+        # Check that the `_set_translated_fields` method has been called with available languages
+        expected_calls = [mocker.call(lang, name=self.translated_name.capitalize()) for lang in languages]
+        self.mock_set_translated_fields.assert_has_calls(expected_calls, any_order=False)
+        assert self.mock_set_translated_fields.call_count == len(expected_calls)
+
+        # Check that the `save_translation` method has been called the correct number of times
+        assert self.mock_save_translation.call_count == len(expected_calls)
 
     def test_translate(self, mocker):
         # Mock `translate` method in DeeplTranslator

--- a/backend/apps/utils/translation/tests/test_tasks.py
+++ b/backend/apps/utils/translation/tests/test_tasks.py
@@ -1,7 +1,4 @@
 import pytest
-from deep_translator import DeeplTranslator
-from django.conf import settings
-from parler.models import TranslatableModelMixin
 
 from apps.utils.translation.tasks import redis_client, translate_fields_task
 from apps.utils.translation.tests.conftest import DummyModel
@@ -10,17 +7,10 @@ from apps.utils.translation.tests.conftest import DummyModel
 class TestTranslateTask:
     @pytest.fixture(autouse=True)
     def setup(self, mocker):
-        instance_name = "Test Model"
-        self.translated_name = f"Translated {instance_name}"
-        self.instance = DummyModel(id=1, name=instance_name)
-
+        self.instance = DummyModel(id=1, name="Test Model")
+        self.model_label = self.instance._meta.label  # type: ignore
         self.mock_get_obj = mocker.patch.object(DummyModel.objects, "get", return_value=self.instance)
-        self.mock_translate = mocker.patch.object(DeeplTranslator, "translate", return_value=self.translated_name)
-        self.mock_create_translation = mocker.patch.object(
-            TranslatableModelMixin,
-            "create_translation",
-            return_value=None,
-        )
+        self.translate_field = mocker.patch.object(self.instance, "translate_field")
 
     def test_translate_fields_task_with_unlocked_redis(self, mocker):
         # Mock Redis client methods
@@ -29,13 +19,13 @@ class TestTranslateTask:
         mock_redis_delete = mocker.patch.object(redis_client, "delete", return_value=True)
 
         translate_fields_task.apply_async(
-            args=(self.instance._meta.label, self.instance.pk, self.instance.language_code),  # type: ignore
+            args=(self.model_label, self.instance.pk, self.instance.language_code),
             queue="high_priority",
             priority=10,
         )
 
         # Check Redis lock methods
-        lock_key = f"translate_task_lock_{self.instance.pk}"
+        lock_key = f"translate_task_lock_{self.model_label}:{self.instance.pk}"
 
         # Check if the Redis lock was set and expired
         mock_redis_setnx.assert_called_once_with(lock_key, "locked")
@@ -47,18 +37,11 @@ class TestTranslateTask:
         # Check that the `get` method has been called once
         self.mock_get_obj.assert_called_once_with(pk=self.instance.pk)
 
-        # Get a language list
-        languages = [code for (code, lang) in settings.LANGUAGES if code != self.instance.language_code]
-
-        # Check that the `translate` method has been called with instance name
-        expected_calls = [mocker.call(self.instance.name) for _ in range(len(languages))]  # type: ignore
-        self.mock_translate.assert_has_calls(expected_calls, any_order=False)
-        assert self.mock_translate.call_count == len(expected_calls)
-
-        # Check that the `create_translation` method has been called with available languages
-        expected_calls = [mocker.call(lang, name=self.translated_name) for lang in languages]
-        self.mock_create_translation.assert_has_calls(expected_calls, any_order=False)
-        assert self.mock_create_translation.call_count == len(expected_calls)
+        expected_calls = [
+            mocker.call(field, getattr(self.instance, field)) for field in self.instance.get_translated_fields()
+        ]
+        self.translate_field.assert_has_calls(expected_calls, any_order=False)
+        assert self.translate_field.call_count == len(expected_calls)
 
     def test_translate_fields_task_with_locked_redis(self, mocker):
         # Mock Redis client to simulate locked redis (setnx returns False)
@@ -74,7 +57,7 @@ class TestTranslateTask:
         )
 
         # Check that the `setnx` method has been called and returned False
-        lock_key = f"translate_task_lock_{self.instance.pk}"
+        lock_key = f"translate_task_lock_{self.model_label}:{self.instance.pk}"
         mock_redis_setnx.assert_called_once_with(lock_key, "locked")
 
         # Ensure that `expire` and `delete` were never called because the lock was not acquired
@@ -83,5 +66,3 @@ class TestTranslateTask:
 
         # Ensure that no translation methods were called, since the lock was not acquired
         self.mock_get_obj.assert_not_called()
-        self.mock_create_translation.assert_not_called()
-        self.mock_translate.assert_not_called()


### PR DESCRIPTION
- When saving a model that has more than one field for translation, an error that such a translation already exists occurred.
- Updated a redis locking key (a more unique name is used).
- Test suites have been updated.