### PR TITLE
Migrate Celery to Redis broker and unify queue usage via QueueEnum

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,7 +35,7 @@ VITE_API_URL=http://localhost:8000/api
 
 # --- Redis ------------------------------------------------------------------------------------------------------------
 REDIS_PORT=6379
-REDIS_BROKER_URL=redis://redis:6379/1
+REDIS_BROKER_URL="redis://redis:${REDIS_PORT}/0"
 
 # --- RabbitMQ ---------------------------------------------------------------------------------------------------------
 RABBITMQ_DEFAULT_USER=admin
@@ -47,7 +47,7 @@ RABBITMQ_BROKER_URL="pyamqp://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@
 
 # --- Celery -----------------------------------------------------------------------------------------------------------
 CELERY_BROKER_URL="${RABBITMQ_BROKER_URL}"
-CELERY_RESULT_BACKEND=rpc://
+CELERY_RESULT_BACKEND="${REDIS_BROKER_URL}"
 
 # --- Email ------------------------------------------------------------------------------------------------------------
 EMAIL_HOST_USER=tvorcha.lavka.ua@gmail.com

--- a/backend/docker/docker-compose.rabbitmq.yml
+++ b/backend/docker/docker-compose.rabbitmq.yml
@@ -3,13 +3,13 @@ services:
     image: rabbitmq:management
     container_name: rabbitmq
     env_file: ../../.env
+    restart: always
     healthcheck:
       test: [ "CMD", "rabbitmq-diagnostics", "ping" ]
       start_period: 30s
       interval: 30s
       timeout: 10s
       retries: 5
-    restart: always
     ports:
       - ${RABBITMQ_PORT:-5672}:5672
       - ${RABBITMQ_MANAGEMENT_PORT:-15672}:15672

--- a/backend/docker/docker-compose.redis.yml
+++ b/backend/docker/docker-compose.redis.yml
@@ -2,6 +2,7 @@ services:
   redis:
     image: redis:latest
     container_name: redis
+    env_file: ../../.env
     restart: always
     healthcheck:
       test: [ "CMD-SHELL", "redis-cli", "ping" ]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -149,6 +149,10 @@ module = [
     "social_django.*",
 ]
 
+[[tool.mypy.overrides]]
+module = ["tasks.*", "*.tasks"]
+disable_error_code = ["misc"]
+
 
 [tool.django-stubs]
 django_settings_module = "core.settings.development"

--- a/backend/scripts/entrypoint.py
+++ b/backend/scripts/entrypoint.py
@@ -63,6 +63,7 @@ def run_django(_type: str) -> None:
 
 def run_celery(worker: str) -> None:
     from core.celery.client import app
+    from core.celery.enums import QueueEnum
 
     celery_config = CeleryConfig(
         beat=[
@@ -74,28 +75,28 @@ def run_celery(worker: str) -> None:
             "--loglevel=info",
             "--autoscale=10,1",
             "--max-tasks-per-child=50",
-            "--queues=database.queue",
+            "--queues=%s" % QueueEnum.DATABASE,
         ],
         elasticsearch=[
             "worker",
             "--loglevel=info",
             "--autoscale=10,1",
             "--max-tasks-per-child=50",
-            "--queues=elasticsearch.queue",
+            "--queues=%s" % QueueEnum.ELASTICSEARCH,
         ],
         notification=[
             "worker",
             "--loglevel=info",
             "--autoscale=10,1",
             "--max-tasks-per-child=50",
-            "--queues=notification.queue",
+            "--queues=%s" % QueueEnum.NOTIFICATION,
         ],
         statistics=[
             "worker",
             "--loglevel=info",
             "--autoscale=5,1",
             "--max-tasks-per-child=25",
-            "--queues=statistics.queue",
+            "--queues=%s" % QueueEnum.STATISTICS,
         ],
     )
 

--- a/backend/src/apps/category/receivers.py
+++ b/backend/src/apps/category/receivers.py
@@ -4,6 +4,7 @@ from django.db.models.signals import pre_delete, pre_save
 from django.dispatch import receiver
 
 from apps.utils.image import admin_compress_image
+from core.celery.enums import QueueEnum
 
 from .middleware import CategoryStatisticMiddleware
 from .models import CardImage, CategoryImage
@@ -36,9 +37,9 @@ def delete_category_card_image(sender: CardImage, instance: CardImage, **kwargs:
 # --- Receivers to increase category stats -----------------------------------------------------------------------------
 @receiver(category_viewed, sender=CategoryStatisticMiddleware)
 def handle_category_viewed(sender: CategoryStatisticMiddleware, category_id: int, **kwargs: Any) -> None:  # noqa: F841
-    update_category_views_task.apply_async(args=(category_id,), queue="statistics.queue", priority=10)
+    update_category_views_task.apply_async(args=(category_id,), queue=QueueEnum.STATISTICS, priority=10)
 
 
 @receiver(purchase_in_category)
 def handle_category_purchase(sender: Any, category_id: int, **kwargs: Any) -> None:  # noqa: F841
-    update_category_purchase_task.apply_async(args=(category_id,), queue="statistics.queue", priority=10)
+    update_category_purchase_task.apply_async(args=(category_id,), queue=QueueEnum.STATISTICS, priority=10)

--- a/backend/src/apps/category/tasks.py
+++ b/backend/src/apps/category/tasks.py
@@ -1,11 +1,12 @@
 from celery import Task
 
 from core.celery.client import app
+from core.celery.enums import QueueEnum
 
 from .models import Statistics
 
 
-@app.task(name="statistics.category.increment.views", queue="statistics.queue", bind=True)  # type: ignore[misc]
+@app.task(name="statistics.category.increment.views", queue=QueueEnum.STATISTICS, bind=True)
 def update_category_views_task(self: Task, category_id: int) -> str:
     try:
         statistics, created = Statistics.objects.get_or_create(category_id=category_id)
@@ -15,7 +16,7 @@ def update_category_views_task(self: Task, category_id: int) -> str:
         raise self.retry(exc=e)
 
 
-@app.task(name="statistics.category.increment.purchases", queue="statistics.queue", bind=True)  # type: ignore[misc]
+@app.task(name="statistics.category.increment.purchases", queue=QueueEnum.STATISTICS, bind=True)
 def update_category_purchase_task(self: Task, category_id: int) -> str:
     try:
         statistics, created = Statistics.objects.get_or_create(category_id=category_id)

--- a/backend/src/apps/category/tests/test_receivers.py
+++ b/backend/src/apps/category/tests/test_receivers.py
@@ -15,6 +15,7 @@ from apps.category.receivers import (
     handle_category_viewed,
 )
 from apps.category.tasks import update_category_purchase_task, update_category_views_task
+from core.celery.enums import QueueEnum
 
 ModelType: TypeAlias = type[CategoryImage | CardImage]
 
@@ -75,7 +76,7 @@ class TestStatisticsReceivers:
         handle_category_viewed(sender=CategoryStatisticMiddleware(mocker.ANY), category_id=1)
 
         # Check that the task has been called once with the correct arguments
-        mock_task.assert_called_once_with(args=(1,), queue="statistics.queue", priority=10)
+        mock_task.assert_called_once_with(args=(1,), queue=QueueEnum.STATISTICS, priority=10)
 
     def test_handle_category_purchase(self, mocker: MockerFixture) -> None:
         # Mock the `update_category_purchase_task` task
@@ -85,4 +86,4 @@ class TestStatisticsReceivers:
         handle_category_purchase(sender=mocker.ANY, category_id=1)
 
         # Check that the task has been called once with the correct arguments
-        mock_task.assert_called_once_with(args=(1,), queue="statistics.queue", priority=10)
+        mock_task.assert_called_once_with(args=(1,), queue=QueueEnum.STATISTICS, priority=10)

--- a/backend/src/apps/email/tasks.py
+++ b/backend/src/apps/email/tasks.py
@@ -10,6 +10,7 @@ from django.utils.translation import gettext_lazy as _
 from apps.user.models import User
 from apps.user_auth.models import VerificationCode
 from core.celery.client import app
+from core.celery.enums import QueueEnum
 
 from .choices import EmailType
 
@@ -24,7 +25,7 @@ def send_verify_email(email: str) -> tuple[AsyncResult, str]:
     return (
         send_verification_code_task.apply_async(
             args=(email, email_type, template, subject, body),
-            queue="notification.queue",
+            queue=QueueEnum.NOTIFICATION,
             priority=0,
         ),
         api_message,
@@ -46,14 +47,14 @@ def send_reset_password(user: User) -> tuple[AsyncResult, str]:
         send_verification_code_task.apply_async(
             args=(user.email, email_type, template, subject, body),
             kwargs={"username": user.username},
-            queue="notification.queue",
+            queue=QueueEnum.NOTIFICATION,
             priority=0,
         ),
         api_message,
     )
 
 
-@app.task(name="notification.email.verification", queue="notification.queue", bind=True)  # type: ignore[misc]
+@app.task(name="notification.email.verification", queue=QueueEnum.NOTIFICATION, bind=True)
 def send_verification_code_task(  # noqa: CFQ002 (7 args, allowed 6)
     self: Task,
     recipient: str,
@@ -83,7 +84,7 @@ def send_verification_code_task(  # noqa: CFQ002 (7 args, allowed 6)
         raise self.retry(exc=e)
 
 
-@app.task(name="notification.email.welcome", queue="notification.queue", bind=True)  # type: ignore[misc]
+@app.task(name="notification.email.welcome", queue=QueueEnum.NOTIFICATION, bind=True)
 def send_welcome_email_task(self: Task, email: str) -> None:
     try:
         user = User.objects.get(email=email)

--- a/backend/src/apps/product/receivers.py
+++ b/backend/src/apps/product/receivers.py
@@ -2,6 +2,7 @@
 # from django.dispatch import receiver
 
 # from apps.product.models import ProductImage
+# from core.celery.enums import QueueEnum
 
 # from .tasks import remove_images_task
 
@@ -13,6 +14,6 @@
 #
 #     remove_images_task.apply_async(
 #         args=(images_to_delete,),
-#         queue="celery",
+#         queue=QueueEnum.ORCHESTRATOR,
 #         priority=10,
 #     )

--- a/backend/src/apps/product/tasks.py
+++ b/backend/src/apps/product/tasks.py
@@ -5,18 +5,19 @@ from uuid import UUID
 from celery import Task
 
 from core.celery.client import app
+from core.celery.enums import QueueEnum
 
 from .dto import OptimizeProductImages
 from .models import Product
 
 # from django.core.files.storage import default_storage
 
-# @app.task  # type: ignore[misc]
+# @app.task
 # def remove_images_task(file_names: list[str]):
 #     [default_storage.delete(file_name) for file_name in file_names]
 
 
-@app.task(name="database.product.create", queue="database.queue", bind=True)  # type: ignore[misc]
+@app.task(name="database.product.create", queue=QueueEnum.DATABASE, bind=True)
 def create_db_product_task(self: Task, validated_data: str, user_id: str, session_id: str) -> None:
     """Create product in database and call next task to optimize images."""
     data: dict[str, Any] = loads(validated_data)
@@ -35,4 +36,4 @@ def create_db_product_task(self: Task, validated_data: str, user_id: str, sessio
     )
 
     kwargs = {"json_str": optimize_dto.model_dump_json()}
-    app.send_task(name="optimize.product.images", queue="optimize.queue", kwargs=kwargs)
+    app.send_task(name="optimize.product.images", queue=QueueEnum.FILE_OPTIMIZER, kwargs=kwargs)

--- a/backend/src/apps/product/views.py
+++ b/backend/src/apps/product/views.py
@@ -18,6 +18,7 @@ from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
 from uuid6 import uuid7
 
 from core.celery.client import app
+from core.celery.enums import QueueEnum
 
 from .filters import ProductPrivateFilter, ProductPublicFilter
 from .models import Product
@@ -101,7 +102,7 @@ class ProductPrivateViewSet(ModelViewSet[Product]):
 
         app.send_task(
             name="database.product.create",
-            queue="database.queue",
+            queue=QueueEnum.DATABASE,
             kwargs={
                 "user_id": str(self.request.user.pk),
                 "session_id": str(serializer.validated_data.pop("session_id")),

--- a/backend/src/apps/review/tests/test_views.py
+++ b/backend/src/apps/review/tests/test_views.py
@@ -2,10 +2,10 @@ from collections import namedtuple as nt
 from typing import Any, cast
 
 import pytest
-from _pytest.fixtures import FixtureRequest
 from django.contrib.contenttypes.models import ContentType, ContentTypeManager
 from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
+from pytest import FixtureRequest
 from pytest_mock import MockFixture
 from rest_framework import status
 from rest_framework.exceptions import NotFound

--- a/backend/src/apps/user_auth/jwt/tasks.py
+++ b/backend/src/apps/user_auth/jwt/tasks.py
@@ -3,9 +3,10 @@ from django.utils import timezone
 from rest_framework_simplejwt.token_blacklist.models import BlacklistedToken, OutstandingToken
 
 from core.celery.client import app
+from core.celery.enums import QueueEnum
 
 
-@app.task(name="database.prune.expired.tokens", queue="database.queue", bind=True)  # type: ignore[misc]
+@app.task(name="database.prune.expired.tokens", queue=QueueEnum.DATABASE, bind=True)
 def prune_expired_tokens_task(self: Task) -> None:
     try:
         # Removing expired tokens from BlacklistedToken

--- a/backend/src/apps/user_auth/signals.py
+++ b/backend/src/apps/user_auth/signals.py
@@ -4,6 +4,7 @@ from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
 from core.celery.client import app
+from core.celery.enums import QueueEnum
 
 from .models import VerificationCode as Code
 from .tasks import prune_unused_verification_code_task
@@ -15,7 +16,7 @@ def delete_unused_code(sender: Code, instance: Code, **kwargs: Any) -> None:  # 
     task = prune_unused_verification_code_task.apply_async(
         args=(instance.id,),
         countdown=600,
-        queue="database.queue",
+        queue=QueueEnum.DATABASE,
         priority=0,
     )
     sender.objects.filter(id=instance.id).update(uuid=task.id)

--- a/backend/src/apps/user_auth/social/views.py
+++ b/backend/src/apps/user_auth/social/views.py
@@ -12,6 +12,7 @@ from apps.email.tasks import send_welcome_email_task
 from apps.user.serializers import UserSerializer
 from apps.user_auth.jwt.mixins import TokenMixin
 from apps.user_auth.serializers import UserAuthSerializer
+from core.celery.enums import QueueEnum
 
 from .mixins import BackendMixin
 from .serializers import SocialCallbackOAuth2Serializer, SocialOAuth2RedirectSerializer
@@ -51,7 +52,7 @@ class SocialOAuth2CallbackView(CreateAPIView[Any], TokenMixin, BackendMixin):
 
         if user and not user.is_email_verified:
             user.verify_email()
-            send_welcome_email_task.apply_async((user.email,), queue="notification.queue", priority=0)
+            send_welcome_email_task.apply_async((user.email,), queue=QueueEnum.NOTIFICATION, priority=0)
 
         if user and user.is_active:
             response_data = {"user": UserSerializer(user).data, "token": {**self.get_token_pair(user)}}

--- a/backend/src/apps/user_auth/tasks.py
+++ b/backend/src/apps/user_auth/tasks.py
@@ -2,9 +2,10 @@ from celery import Task
 
 from apps.user_auth.models import VerificationCode
 from core.celery.client import app
+from core.celery.enums import QueueEnum
 
 
-@app.task(name="database.prune.unused.verification-code", queue="database.queue", bind=True)  # type: ignore[misc]
+@app.task(name="database.prune.unused.verification-code", queue=QueueEnum.DATABASE, bind=True)
 def prune_unused_verification_code_task(self: Task, code_id: int) -> None:
     try:
         code = VerificationCode.objects.get(id=code_id)

--- a/backend/src/apps/user_auth/tests/test_celery.py
+++ b/backend/src/apps/user_auth/tests/test_celery.py
@@ -7,6 +7,7 @@ from apps.email.choices import EmailType
 from apps.user_auth.models import VerificationCode
 from apps.user_auth.tasks import prune_unused_verification_code_task
 from core.celery.client import app
+from core.celery.enums import QueueEnum
 from core.tests.typing import CodeFactoryTuple, UsersTuple
 
 # ----- Test Case Schemas ----------------------------------------------------------------------------------------------
@@ -40,7 +41,7 @@ def test_prune_unused_verification_code_task(
 
     result = prune_unused_verification_code_task.apply_async(
         args=(code_obj.id,),
-        queue="database.queue",
+        queue=QueueEnum.DATABASE,
         priority=0,
     )
     result.wait()

--- a/backend/src/apps/utils/translation/models.py
+++ b/backend/src/apps/utils/translation/models.py
@@ -8,6 +8,8 @@ from django.db.models import Model
 from parler.managers import TranslatableManager
 from parler.models import TranslatableModel
 
+from core.celery.enums import QueueEnum
+
 from .tasks import translate_fields_task
 
 
@@ -31,7 +33,7 @@ class AutoTranslatableModel(TranslatableModel, Model):  # type: ignore[misc]
         """Starts the celery task to translate each field in translatable_fields."""
         translate_fields_task.apply_async(
             args=(self._meta.label, self.pk, self.language_code),
-            queue="database.queue",
+            queue=QueueEnum.DATABASE,
             priority=10,
         )
 

--- a/backend/src/apps/utils/translation/tasks.py
+++ b/backend/src/apps/utils/translation/tasks.py
@@ -7,9 +7,10 @@ from django_redis.cache import RedisCache
 from parler.models import TranslatableModel
 
 from core.celery.client import app
+from core.celery.enums import QueueEnum
 
 
-@app.task(name="database.translations.create", queue="database.queue", bind=True)  # type: ignore[misc]
+@app.task(name="database.translations.create", queue=QueueEnum.DATABASE, bind=True)
 def translate_fields_task(self: Task, app_label: str, instance_pk: int, language_code: str) -> None:
     """Create translations to each field in translatable_fields."""
     lock_key = f"translate_task_lock_{app_label}:{instance_pk}"

--- a/backend/src/apps/utils/translation/tests/test_model.py
+++ b/backend/src/apps/utils/translation/tests/test_model.py
@@ -9,6 +9,7 @@ from pytest_mock import MockerFixture
 
 from apps.utils.translation.models import AutoTranslatableModel
 from apps.utils.translation.tasks import translate_fields_task
+from core.celery.enums import QueueEnum
 
 
 class DummyModel(AutoTranslatableModel):
@@ -52,7 +53,7 @@ class TestAutoTranslatableModel:
         # Check that the translation task was called with the correct arguments
         mock_task.assert_called_once_with(
             args=(self.instance._meta.label, self.instance.pk, self.instance.language_code),
-            queue="database.queue",
+            queue=QueueEnum.DATABASE,
             priority=10,
         )
 

--- a/backend/src/apps/utils/translation/tests/test_tasks.py
+++ b/backend/src/apps/utils/translation/tests/test_tasks.py
@@ -6,6 +6,7 @@ from django_redis.cache import RedisCache
 from pytest_mock import MockerFixture
 
 from apps.utils.translation.tasks import translate_fields_task
+from core.celery.enums import QueueEnum
 
 from .test_model import DummyModel
 
@@ -27,7 +28,7 @@ class TestTranslateTask:
 
         translate_fields_task.apply_async(
             args=(self.model_label, self.instance.pk, self.instance.language_code),
-            queue="database.queue",
+            queue=QueueEnum.DATABASE,
             priority=10,
         )
 
@@ -59,7 +60,7 @@ class TestTranslateTask:
         # Run the task
         translate_fields_task.apply_async(
             args=(self.instance._meta.label, self.instance.pk, self.instance.language_code),
-            queue="database.queue",
+            queue=QueueEnum.DATABASE,
             priority=10,
         )
 

--- a/backend/src/core/celery/client.py
+++ b/backend/src/core/celery/client.py
@@ -6,6 +6,8 @@ from celery.schedules import crontab
 from core.celery.settings import celery_settings
 from core.utils import settings_module
 
+from .enums import QueueEnum
+
 # Defining django settings
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", settings_module)
 
@@ -26,9 +28,9 @@ app.conf.update(
 # Configure celery beat schedule
 app.conf.beat_schedule = {
     "database.prune.expired.tokens": {
-        "task": "apps.user_auth.jwt.tasks.prune_expired_tokens_task",
+        "task": "database.prune.expired.tokens",
         "schedule": crontab(hour="0", minute="0"),
-        "options": {"queue": "database.queue"},
+        "options": {"queue": QueueEnum.DATABASE},
     }
 }
 

--- a/backend/src/core/celery/enums.py
+++ b/backend/src/core/celery/enums.py
@@ -1,0 +1,14 @@
+from enum import StrEnum
+
+
+class QueueEnum(StrEnum):
+    DATABASE = "database.queue"
+    ELASTICSEARCH = "elasticsearch.queue"
+
+    FILE_OPTIMIZER = "file-optimizer.queue"
+    FILE_UPLOADER_DB = "file-uploader.db.queue"
+    FILE_UPLOADER_S3 = "file-uploader.s3.queue"
+
+    NOTIFICATION = "notification.queue"
+    ORCHESTRATOR = "orchestrator.queue"
+    STATISTICS = "statistics.queue"

--- a/backend/src/core/celery/settings.py
+++ b/backend/src/core/celery/settings.py
@@ -4,7 +4,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class CelerySettings(BaseSettings):
     APP_NAME: str = "backend"
     BROKER_URL: str = "pyamqp://admin:admin@rabbitmq:5672//"
-    RESULT_BACKEND: str = "rpc://"
+    RESULT_BACKEND: str = "redis://redis:6379/0"
 
     model_config = SettingsConfigDict(
         env_prefix="CELERY_",

--- a/backend/src/core/settings/base.py
+++ b/backend/src/core/settings/base.py
@@ -175,7 +175,7 @@ PARLER_LANGUAGES = {
     },
 }
 
-TIME_ZONE = "Europe/Kyiv"
+TIME_ZONE = "UTC"
 
 USE_I18N = True
 


### PR DESCRIPTION
- Switched Celery broker from `rpc://` to `redis://`
- Introduced `QueueEnum` in all Django apps with tasks to standardize queue assignment
- Updated Celery config, .env, and docker-compose as needed