### PR TITLE
feat(search): improve search API response structure and exact match logic

### DIFF
--- a/backend/src/apps/search/elastic/documents/base.py
+++ b/backend/src/apps/search/elastic/documents/base.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from django.db.models import Model
 from django.utils.translation import get_language
 from elasticsearch.helpers import bulk
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from apps.search.elastic.models import TranslatableText, TranslatableTextList
 from core.elasticsearch.client import elastic
@@ -14,6 +14,7 @@ _Model = TypeVar("_Model", bound=Model)
 
 class BaseDocument(BaseModel, Generic[_Model]):
     id: UUID | int  # noqa: VNE003
+    score: float = Field(default_factory=float)
 
     index_name: ClassVar[str]
     index_settings: ClassVar[dict[str, Any]]
@@ -28,7 +29,7 @@ class BaseDocument(BaseModel, Generic[_Model]):
             "_op_type": "index",
             "_index": self.index_name,
             "_id": str(self.id),
-            **self.model_dump(exclude={"id"}),
+            **self.model_dump(exclude={"id", "score"}),
         }
 
     @classmethod
@@ -85,7 +86,7 @@ class BaseDocument(BaseModel, Generic[_Model]):
         elastic.index(
             index=cls.index_name,
             id=str(doc.id),
-            document=doc.model_dump(exclude={"id"}),
+            document=doc.model_dump(exclude={"id", "score"}),
             refresh="wait_for",
         )
 
@@ -123,6 +124,7 @@ class BaseDocument(BaseModel, Generic[_Model]):
         def normalize(hit: dict[str, Any]) -> "BaseDocument[_Model]":
             source = hit["_source"].copy()
             source["id"] = hit["_id"]
+            source["score"] = hit["_score"]
             return cls.model_validate(source)
 
         return [normalize(hit).model_serialize() for hit in hits]

--- a/backend/src/apps/search/elastic/documents/product.py
+++ b/backend/src/apps/search/elastic/documents/product.py
@@ -91,4 +91,7 @@ class ProductDocument(BaseDocument[Product]):
             if field.annotation == list[ImageSchema]:
                 data[key] = ImageSchema.multi_model_serialize(value, product_id=str(self.id))
 
+            if field.annotation == list[FiltersSchema]:
+                data[key] = FiltersSchema.get_filter_value_ids(value)
+
         return data

--- a/backend/src/apps/search/elastic/query/builder.py
+++ b/backend/src/apps/search/elastic/query/builder.py
@@ -54,7 +54,7 @@ class ElasticMultiSearchBuilder:
     @staticmethod
     def _get_query_terms(query: str) -> list[str]:
         """Remove punctuation, normalize Unicode, lowercase, and split into terms."""
-        text = sub(r"[^\w\s\-]", "", normalize("NFKD", query), flags=UNICODE)
+        text = sub(r"[^\w\s\-]", "", normalize("NFKC", query), flags=UNICODE)
         return [
             term
             # Split text into lowercase terms
@@ -142,7 +142,7 @@ class ElasticMultiSearchBuilder:
                 }
             )
             for nested_field in self._nested_fields:
-                nested_field, _ = self._split_boost(nested_field)
+                nested_field, boost = self._split_boost(nested_field)
                 clauses.append(
                     {
                         "nested": {
@@ -152,6 +152,7 @@ class ElasticMultiSearchBuilder:
                                     nested_field: {
                                         "query": term,
                                         "fuzziness": fuzziness,
+                                        "boost": boost,
                                     }
                                 }
                             },

--- a/backend/src/apps/search/elastic/schemas/filters.py
+++ b/backend/src/apps/search/elastic/schemas/filters.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from pydantic import BaseModel
 
 from apps.search.elastic.models import TranslatableText
@@ -8,3 +10,8 @@ class FiltersSchema(BaseModel):
     type: str  # noqa: VNE003
     value_id: int
     value: TranslatableText
+
+    @classmethod
+    def get_filter_value_ids(cls, values: list[dict[str, Any]]) -> list[int]:
+        """Get list of filter value ids."""
+        return [cls(**data).value_id for data in values]

--- a/backend/src/apps/search/serializers.py
+++ b/backend/src/apps/search/serializers.py
@@ -1,8 +1,11 @@
+from collections import defaultdict
 from datetime import datetime
-from typing import Any
+from functools import cached_property
+from typing import Annotated, Any, Literal, Self
+from unicodedata import normalize
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from rest_framework import serializers
 
 from apps.product.images import ImageBundle
@@ -13,31 +16,102 @@ class SearchParamsSerializer(serializers.Serializer[Any]):
     query = serializers.CharField(required=True)
 
 
-class BaseDocumentSerializer(BaseModel):
-    id: UUID | int  # noqa: VNE003
-
-
-class CategoryDocumentSerializer(BaseDocumentSerializer):
-    slug: str
+class BaseSearchSerializer(BaseModel):
+    id: int  # noqa: VNE003
+    score: float
+    exact_match: bool = False
+    type: Literal["category", "product"]  # noqa: VNE003
     title: str
-    url: str
+
+    filter_ids: list[int] = Field(
+        default_factory=list,
+        alias="filters",
+        serialization_alias="filter_ids",
+    )
     full_path: list[str]
 
+    model_config = ConfigDict(
+        validate_by_name=True,
+        validate_by_alias=True,
+    )
 
-class ProductDocumentSerializer(BaseDocumentSerializer):
-    title: str
+
+class CategorySearchResult(BaseSearchSerializer):
+    type: Literal["category"] = "category"  # noqa: VNE003
+    slug: str
+    url_path: str = Field(alias="url", serialization_alias="url_path")
+
+
+class ProductSearchResult(BaseSearchSerializer):
+    id: int = Field(alias="category_id", serialization_alias="id")  # noqa: VNE003
+    product_id: UUID = Field(alias="id", serialization_alias="product_id")
+    type: Literal["product"] = "product"  # noqa: VNE003
+
+
+class ProductDetailSearchResult(ProductSearchResult):
     description: str
     price: float
     is_vip: bool
     date_published: datetime
 
     owner: OwnerSchema
-    category_id: int
     images: list[ImageBundle]
-    full_path: list[str]
+
+
+_SearchResult = Annotated[CategorySearchResult | ProductSearchResult, Field(discriminator="type")]
 
 
 class SearchPanelResult(BaseModel):
+    """
+    Represents combined search results for the search panel
+    with categories and products sorted by exact match and score.
+    """
+
     query: str
-    categories: list[CategoryDocumentSerializer]
-    products: list[ProductDocumentSerializer]
+    results: list[_SearchResult] = Field(default_factory=list)
+
+    categories: list[CategorySearchResult] = Field(exclude=True)
+    products: list[ProductSearchResult] = Field(exclude=True)
+
+    @cached_property
+    def normalized_query(self) -> str:
+        """Return normalized query."""
+        return self.normalize(self.query)
+
+    @staticmethod
+    def normalize(text: str) -> str:
+        """Normalize text to lowercase and remove diacritics."""
+        return normalize("NFKC", text).strip().lower()
+
+    @model_validator(mode="after")
+    def prepare_results(self) -> Self:
+        """
+        Post-processing of search results:
+        - Aggregates filter IDs from products and attaches them to matching categories.
+        - Merges categories and products into a unified result list.
+        - Sets `exact_match=True` for results whose title exactly matches the normalized query.
+        - Sorts results: exact matches appear first, then others by descending score.
+        """
+        filters: dict[int, set[int]] = defaultdict(set)
+
+        # Aggregate filter IDs
+        for product in self.products:
+            filters[product.id] |= set(product.filter_ids)
+
+        for category in self.categories:
+            category.filter_ids = list(filters[category.id])
+
+        # Merge categories and products
+        self.results = self.categories + self.products
+
+        # Set exact match
+        for result in self.results:
+            result.exact_match = self.is_exact_match(result.title)
+
+        # Sort results
+        self.results.sort(key=lambda x: (not x.exact_match, -x.score))
+
+        return self
+
+    def is_exact_match(self, title: str) -> bool:
+        return self.normalized_query == self.normalize(title)

--- a/backend/src/apps/search/urls.py
+++ b/backend/src/apps/search/urls.py
@@ -1,7 +1,11 @@
 from django.urls import path
+from drf_spectacular.utils import extend_schema
 
 from .views import SearchPanelView
 
+SchemaTag = "Search"
+SearchPanelViewExtended = extend_schema(tags=[SchemaTag])(SearchPanelView)
+
 urlpatterns = [
-    path("", SearchPanelView.as_view(), name="search"),
+    path("", SearchPanelViewExtended.as_view(), name="search"),
 ]

--- a/backend/src/apps/search/views.py
+++ b/backend/src/apps/search/views.py
@@ -33,15 +33,15 @@ class SearchPanelView(GenericAPIView[Any]):
         builder.add(
             index="category",
             fields=[],
-            translatable_fields=["title^2", "full_path"],
+            translatable_fields=["title^10", "full_path^5"],
             collapse_field="title",
             size=5,
         )
         builder.add(
             index="product",
-            fields=["title^4", "description^2"],
-            translatable_fields=["full_path^3"],
-            nested_translatable_fields=["filters.value^5"],
+            fields=["title^10", "description^5"],
+            translatable_fields=["full_path^10"],
+            nested_translatable_fields=["filters.value^25"],
             collapse_field="title",
             size=5,
         )


### PR DESCRIPTION
- Added `score` field to base search documents for deserialization from Elasticsearch (excluded from indexing).
- Implemented value ID extraction in `FiltersSchema` for products to support filter aggregation.
- Adjusted `boost` for `nested_field` in query builder and aligned boosts in `SearchPanelView`.
- Refactored search serializers:
  - Unified `CategorySearchResult` and `ProductSearchResult` under common base `BaseSearchSerializer`.
  - Introduced polymorphic serialization via `type` discriminator.
  - Renamed and aliased fields for cleaner API output (`id`, `product_id`, `url_path`, `filter_ids`).
  - Added `exact_match` flag to mark results whose titles exactly match the normalized query.
  - Implemented post-validation logic in `SearchPanelResult` to:
    - Merge and sort products and categories.
    - Propagate product filters to their categories.
    - Mark exact matches and sort results accordingly.